### PR TITLE
[DO NOT MERGE] Update the plugin

### DIFF
--- a/lib/smart_proxy_dns_route53/dns_route53_configuration.rb
+++ b/lib/smart_proxy_dns_route53/dns_route53_configuration.rb
@@ -1,0 +1,16 @@
+module ::Proxy::Dns::Route53
+  class PluginConfiguration
+    def load_classes
+      require 'smart_proxy_dns_plugin_template/dns_plugin_template_main'
+    end
+
+    def load_dependency_injection_wirings(container_instance, settings)
+      container_instance.dependency :dns_provider, (lambda do
+        ::Proxy::Dns::Route53::Record.new(
+            settings[:aws_access_key],
+            settings[:aws_secret_key],
+            settings[:dns_ttl])
+      end)
+    end
+  end
+end

--- a/lib/smart_proxy_dns_route53/dns_route53_main.rb
+++ b/lib/smart_proxy_dns_route53/dns_route53_main.rb
@@ -53,9 +53,14 @@ module Proxy::Dns::Route53
       @resolver ||= Resolv::DNS.new
     end
 
-    def get_zone(fqdn)
-      domain = fqdn.split('.', 2).last
-      conn.get_zones(domain)[0]
+    def get_zone(name)
+      zones = conn.get_zones
+      name_arr = name.split('.')
+      (1 ... name_arr.size).each do |i|
+        search_domain = name_arr.last(name_arr.size - i).join('.') + "."
+        zone_select = zones.select { |z| z.name == search_domain }
+        return zone_select.first if zone_select.any?
+      end
     end
   end
 end

--- a/lib/smart_proxy_dns_route53/dns_route53_main.rb
+++ b/lib/smart_proxy_dns_route53/dns_route53_main.rb
@@ -10,10 +10,10 @@ module Proxy::Dns::Route53
 
     attr_reader :aws_access_key, :aws_secret_key
 
-    def initialize(a_server = nil, a_ttl = nil)
-      @aws_access_key = Proxy::Dns::Route53::Plugin.settings.aws_access_key
-      @aws_secret_key = Proxy::Dns::Route53::Plugin.settings.aws_secret_key
-      super(a_server, a_ttl || ::Proxy::Dns::Plugin.settings.dns_ttl)
+    def initialize(aws_access_key, aws_secret_key, ttl = nil)
+      @aws_access_key = aws_access_key
+      @aws_secret_key = aws_secret_key
+      super(nil, ttl)
     end
 
     def create_a_record(fqdn, ip)

--- a/lib/smart_proxy_dns_route53/dns_route53_plugin.rb
+++ b/lib/smart_proxy_dns_route53/dns_route53_plugin.rb
@@ -1,16 +1,15 @@
 require 'smart_proxy_dns_route53/dns_route53_version'
+require 'smart_proxy_dns_route53/dns_route53_configuration'
 
 module Proxy::Dns::Route53
   class Plugin < ::Proxy::Provider
     plugin :dns_route53, ::Proxy::Dns::Route53::VERSION
 
-    requires :dns, '>= 1.11'
+    requires :dns, '>= 1.13'
 
-    validate_presence :aws_access_key, :aws_secret_key
+    default_settings :aws_access_key => nil, :aws_secret_key => nil
 
-    after_activation do
-      require 'smart_proxy_dns_route53/dns_route53_main'
-      require 'smart_proxy_dns_route53/route53_dependencies'
-    end
+    load_classes ::Proxy::Dns::Route53::PluginConfiguration
+    load_dependency_injection_wirings ::Proxy::Dns::Route53::PluginConfiguration
   end
 end

--- a/lib/smart_proxy_dns_route53/dns_route53_plugin.rb
+++ b/lib/smart_proxy_dns_route53/dns_route53_plugin.rb
@@ -5,7 +5,7 @@ module Proxy::Dns::Route53
   class Plugin < ::Proxy::Provider
     plugin :dns_route53, ::Proxy::Dns::Route53::VERSION
 
-    requires :dns, '>= 1.13'
+    requires :dns, '>= 1.15'
 
     default_settings :aws_access_key => nil, :aws_secret_key => nil
 

--- a/lib/smart_proxy_dns_route53/route53_dependencies.rb
+++ b/lib/smart_proxy_dns_route53/route53_dependencies.rb
@@ -1,5 +1,0 @@
-require 'dns_common/dependency_injection/dependencies'
-
-class Proxy::Dns::DependencyInjection::Dependencies
-  dependency :dns_provider, Proxy::Dns::Route53::Record
-end

--- a/test/dns_route53_record_test.rb
+++ b/test/dns_route53_record_test.rb
@@ -4,140 +4,125 @@ require 'smart_proxy_dns_route53/dns_route53_plugin'
 require 'smart_proxy_dns_route53/dns_route53_main'
 
 class DnsRoute53RecordTest < Test::Unit::TestCase
+  def setup
+    @provider = Proxy::Dns::Route53::Record.new('foo', 'bar', 86400)
+  end
+
   # Test that correct initialization works
   def test_provider_initialization
-    Proxy::Dns::Route53::Plugin.load_test_settings(:aws_access_key => 'foo', :aws_secret_key => 'bar')
-    provider = klass.new
-    assert_equal 'foo', provider.aws_access_key
-    assert_equal 'bar', provider.aws_secret_key
+    assert_equal 'foo', @provider.aws_access_key
+    assert_equal 'bar', @provider.aws_secret_key
+    assert_equal 86400, @provider.ttl
   end
 
   # Test A record creation
   def test_create_a
-    record = klass.new
-    record.expects(:dns_find).returns(false)
+    @provider.expects(:dns_find).returns(false)
 
     zone = mock()
-    record.expects(:get_zone).with('test.example.com').returns(zone)
+    @provider.expects(:get_zone).with('test.example.com').returns(zone)
 
     dnsrecord = mock(:create => mock(:error? => false))
     Route53::DNSRecord.expects(:new).with('test.example.com', 'A', 86400, ['10.1.1.1'], zone).returns(dnsrecord)
 
-    assert record.create_a_record(fqdn, ip)
+    assert @provider.create_a_record(fqdn, ip)
   end
 
   # Test A record creation fails if the record exists
   def test_create_a_conflict
-    record = klass.new
-    record.expects(:dns_find).returns('10.2.2.2')
-    assert_raise(Proxy::Dns::Collision) { record.create_a_record(fqdn, ip) }
+    @provider.expects(:dns_find).returns('10.2.2.2')
+    assert_raise(Proxy::Dns::Collision) { @provider.create_a_record(fqdn, ip) }
   end
 
   # Test PTR record creation
   def test_create_ptr
-    record = klass.new
-    record.expects(:dns_find).returns(false)
+    @provider.expects(:dns_find).returns(false)
 
     zone = mock()
-    record.expects(:get_zone).with('10.1.1.1').returns(zone)
+    @provider.expects(:get_zone).with('10.1.1.1').returns(zone)
 
     dnsrecord = mock(:create => mock(:error? => false))
     Route53::DNSRecord.expects(:new).with('10.1.1.1', 'PTR', 86400, ['test.example.com'], zone).returns(dnsrecord)
 
-    assert record.create_ptr_record(fqdn, ip)
+    assert @provider.create_ptr_record(fqdn, ip)
   end
 
   # Test PTR record creation fails if the record exists
   def test_create_ptr_conflict
-    record = klass.new
-    record.expects(:dns_find).returns('else.example.com')
-    assert_raise(Proxy::Dns::Collision) { record.create_ptr_record(fqdn, ip) }
+    @provider.expects(:dns_find).returns('else.example.com')
+    assert_raise(Proxy::Dns::Collision) { @provider.create_ptr_record(fqdn, ip) }
   end
 
   # Test A record removal
   def test_remove_a
     zone = mock(:get_records => [mock(:name => 'test.example.com.', :delete => mock(:error? => false))])
-    record = klass.new
-    record.expects(:get_zone).with('test.example.com').returns(zone)
-    assert record.remove_a_record(fqdn)
+    @provider.expects(:get_zone).with('test.example.com').returns(zone)
+    assert @provider.remove_a_record(fqdn)
   end
 
   # Test A record removal fails if the record doesn't exist
   def test_remove_a_not_found
-    record = klass.new
-    record.expects(:get_zone).with('test.example.com').returns(mock(:get_records => []))
-    assert_raise(Proxy::Dns::NotFound) { assert record.remove_a_record(fqdn) }
+    @provider.expects(:get_zone).with('test.example.com').returns(mock(:get_records => []))
+    assert_raise(Proxy::Dns::NotFound) { assert @provider.remove_a_record(fqdn) }
   end
 
   # Test PTR record removal
   def test_remove_ptr
     # FIXME: record name seems incorrect for rDNS
     zone = mock(:get_records => [mock(:name => '10.1.1.1.', :delete => mock(:error? => false))])
-    record = klass.new
-    record.expects(:get_zone).with('10.1.1.1').returns(zone)
-    assert record.remove_ptr_record(ip)
+    @provider.expects(:get_zone).with('10.1.1.1').returns(zone)
+    assert @provider.remove_ptr_record(ip)
   end
 
   # Test PTR record removal fails if the record doesn't exist
   def test_remove_ptr_not_found
-    record = klass.new
-    record.expects(:get_zone).with('10.1.1.1').returns(mock(:get_records => []))
-    assert_raise(Proxy::Dns::NotFound) { assert record.remove_ptr_record(ip) }
+    @provider.expects(:get_zone).with('10.1.1.1').returns(mock(:get_records => []))
+    assert_raise(Proxy::Dns::NotFound) { assert @provider.remove_ptr_record(ip) }
   end
 
   def test_get_zone_forward
-    record = klass.new
     conn = mock()
     conn.expects(:get_zones).with('example.com.').returns([:zone])
-    record.expects(:conn).returns(conn)
-    assert_equal :zone, record.send(:get_zone, 'test.example.com')
+    @provider.expects(:conn).returns(conn)
+    assert_equal :zone, @provider.send(:get_zone, 'test.example.com')
   end
 
   def test_get_zone_reverse
-    record = klass.new
     conn = mock()
     conn.expects(:get_zones).with('1.1.1.').returns([:zone])  # FIXME, incorrect rDNS zone
-    record.expects(:conn).returns(conn)
-    assert_equal :zone, record.send(:get_zone, '10.1.1.1')
+    @provider.expects(:conn).returns(conn)
+    assert_equal :zone, @provider.send(:get_zone, '10.1.1.1')
   end
 
   def test_dns_find_forward
-    record = klass.new
     resolver = mock()
     resolver.expects(:getaddress).with('test.example.com').returns('10.1.1.1')
-    record.expects(:resolver).returns(resolver)
-    assert_equal '10.1.1.1', record.send(:dns_find, 'test.example.com')
+    @provider.expects(:resolver).returns(resolver)
+    assert_equal '10.1.1.1', @provider.send(:dns_find, 'test.example.com')
   end
 
   def test_dns_find_forward_not_found
-    record = klass.new
     resolver = mock()
     resolver.expects(:getaddress).with('test.example.com').raises(Resolv::ResolvError)
-    record.expects(:resolver).returns(resolver)
-    refute record.send(:dns_find, 'test.example.com')
+    @provider.expects(:resolver).returns(resolver)
+    refute @provider.send(:dns_find, 'test.example.com')
   end
 
   def test_dns_find_reverse
-    record = klass.new
     resolver = mock()
     resolver.expects(:getname).with('3.2.1.10').returns('test.example.com')
-    record.expects(:resolver).returns(resolver)
-    assert_equal 'test.example.com', record.send(:dns_find, '10.1.2.3')
+    @provider.expects(:resolver).returns(resolver)
+    assert_equal 'test.example.com', @provider.send(:dns_find, '10.1.2.3')
   end
 
   def test_dns_find_reverse_not_found
-    record = klass.new
     resolver = mock()
     resolver.expects(:getname).with('3.2.1.10').raises(Resolv::ResolvError)
-    record.expects(:resolver).returns(resolver)
-    refute record.send(:dns_find, '10.1.2.3')
+    @provider.expects(:resolver).returns(resolver)
+    refute @provider.send(:dns_find, '10.1.2.3')
   end
 
   private
-
-  def klass
-    Proxy::Dns::Route53::Record
-  end
 
   def fqdn
     'test.example.com'

--- a/test/dns_route53_record_test.rb
+++ b/test/dns_route53_record_test.rb
@@ -71,16 +71,31 @@ class DnsRoute53RecordTest < Test::Unit::TestCase
 	end
 
   def test_get_zone_forward
-    conn = mock()
-    conn.expects(:get_zones).with('example.com.').returns([:zone])
+    zone = stub(:name => 'example.com.')
+    conn = mock(:get_zones => [zone])
     @provider.expects(:conn).returns(conn)
-    assert_equal :zone, @provider.send(:get_zone, 'test.example.com.')
+    assert_equal zone, @provider.send(:get_zone, 'test.example.com.')
   end
 
   def test_get_zone_reverse
-    conn = mock()
-    conn.expects(:get_zones).with('2.1.10.in-addr.arpa.').returns([:zone])
+    zone = stub(:name => '2.1.10.in-addr.arpa.')
+    conn = mock(:get_zones => [zone])
     @provider.expects(:conn).returns(conn)
-    assert_equal :zone, @provider.send(:get_zone, '3.2.1.10.in-addr.arpa.')
+    assert_equal zone, @provider.send(:get_zone, '3.2.1.10.in-addr.arpa.')
+  end
+
+  def test_get_zone_reverse_v6
+    zone = stub(:name => '8.b.d.0.1.0.0.2.ip6.arpa.')
+    conn = mock(:get_zones => [zone])
+    @provider.expects(:conn).returns(conn)
+    assert_equal zone, @provider.send(:get_zone, '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa.')
+  end
+
+  def test_get_zone_longest_match
+    zone = stub(:name => 'sub.example.com.')
+    other = stub(:name => 'example.com.')
+    conn = mock(:get_zones => [other, zone])
+    @provider.expects(:conn).returns(conn)
+    assert_equal zone, @provider.send(:get_zone, 'host.sub.example.com.')
   end
 end

--- a/test/dns_route53_record_test.rb
+++ b/test/dns_route53_record_test.rb
@@ -8,127 +8,79 @@ class DnsRoute53RecordTest < Test::Unit::TestCase
     @provider = Proxy::Dns::Route53::Record.new('foo', 'bar', 86400)
   end
 
-  # Test that correct initialization works
   def test_provider_initialization
     assert_equal 'foo', @provider.aws_access_key
     assert_equal 'bar', @provider.aws_secret_key
     assert_equal 86400, @provider.ttl
   end
 
-  # Test A record creation
-  def test_create_a
-    @provider.expects(:dns_find).returns(false)
-
+  def test_do_create_success
     zone = mock()
-    @provider.expects(:get_zone).with('test.example.com').returns(zone)
+    @provider.expects(:get_zone).with('test.example.com.').returns(zone)
 
     dnsrecord = mock(:create => mock(:error? => false))
-    Route53::DNSRecord.expects(:new).with('test.example.com', 'A', 86400, ['10.1.1.1'], zone).returns(dnsrecord)
+    Route53::DNSRecord.expects(:new).with('test.example.com.', 'A', 86400, ['10.1.2.3'], zone).returns(dnsrecord)
 
-    assert @provider.create_a_record(fqdn, ip)
+    assert @provider.do_create('test.example.com', '10.1.2.3', 'A')
   end
 
-  # Test A record creation fails if the record exists
-  def test_create_a_conflict
-    @provider.expects(:dns_find).returns('10.2.2.2')
-    assert_raise(Proxy::Dns::Collision) { @provider.create_a_record(fqdn, ip) }
-  end
-
-  # Test PTR record creation
-  def test_create_ptr
-    @provider.expects(:dns_find).returns(false)
-
+  def test_do_create_failure
     zone = mock()
-    @provider.expects(:get_zone).with('10.1.1.1').returns(zone)
+    @provider.expects(:get_zone).with('test.example.com.').returns(zone)
 
-    dnsrecord = mock(:create => mock(:error? => false))
-    Route53::DNSRecord.expects(:new).with('10.1.1.1', 'PTR', 86400, ['test.example.com'], zone).returns(dnsrecord)
+    dnsrecord = mock(:create => mock(:error? => true))
+    Route53::DNSRecord.expects(:new).with('test.example.com.', 'A', 86400, ['10.1.2.3'], zone).returns(dnsrecord)
 
-    assert @provider.create_ptr_record(fqdn, ip)
+    assert_raise RuntimeError do
+      @provider.do_create('test.example.com', '10.1.2.3', 'A')
+    end
   end
 
-  # Test PTR record creation fails if the record exists
-  def test_create_ptr_conflict
-    @provider.expects(:dns_find).returns('else.example.com')
-    assert_raise(Proxy::Dns::Collision) { @provider.create_ptr_record(fqdn, ip) }
-  end
+	def test_remove_not_found
+    records = []
+    @provider.expects(:get_zone).with('test.example.com.').returns(mock(:get_records => records))
+		assert_raise ::Proxy::Dns::NotFound do
+      @provider.do_remove('test.example.com', 'A')
+    end
+	end
 
-  # Test A record removal
-  def test_remove_a
-    zone = mock(:get_records => [mock(:name => 'test.example.com.', :delete => mock(:error? => false))])
-    @provider.expects(:get_zone).with('test.example.com').returns(zone)
-    assert @provider.remove_a_record(fqdn)
-  end
+	def test_remove_ignores_incorrect_records
+    records = [
+      mock(:name => 'test.example.com.', :type => 'AAAA'),
+      mock(:name => 'other.example.com.')
+    ]
+    @provider.expects(:get_zone).with('test.example.com.').returns(mock(:get_records => records))
+		assert_raise ::Proxy::Dns::NotFound do
+      @provider.do_remove('test.example.com', 'A')
+    end
+	end
 
-  # Test A record removal fails if the record doesn't exist
-  def test_remove_a_not_found
-    @provider.expects(:get_zone).with('test.example.com').returns(mock(:get_records => []))
-    assert_raise(Proxy::Dns::NotFound) { assert @provider.remove_a_record(fqdn) }
-  end
+	def test_remove_single_record
+    records = [mock(:name => 'test.example.com.', :type => 'A', :delete => mock(:error? => false))]
+    @provider.expects(:get_zone).with('test.example.com.').returns(mock(:get_records => records))
+    assert @provider.do_remove('test.example.com', 'A')
+	end
 
-  # Test PTR record removal
-  def test_remove_ptr
-    # FIXME: record name seems incorrect for rDNS
-    zone = mock(:get_records => [mock(:name => '10.1.1.1.', :delete => mock(:error? => false))])
-    @provider.expects(:get_zone).with('10.1.1.1').returns(zone)
-    assert @provider.remove_ptr_record(ip)
-  end
-
-  # Test PTR record removal fails if the record doesn't exist
-  def test_remove_ptr_not_found
-    @provider.expects(:get_zone).with('10.1.1.1').returns(mock(:get_records => []))
-    assert_raise(Proxy::Dns::NotFound) { assert @provider.remove_ptr_record(ip) }
-  end
+	def test_remove_multiple_records
+    records = [
+      mock(:name => 'test.example.com.', :type => 'A', :delete => mock(:error? => false)),
+      mock(:name => 'test.example.com.', :type => 'A', :delete => mock(:error? => false))
+    ]
+    @provider.expects(:get_zone).with('test.example.com.').returns(mock(:get_records => records))
+    assert @provider.do_remove('test.example.com', 'A')
+	end
 
   def test_get_zone_forward
     conn = mock()
     conn.expects(:get_zones).with('example.com.').returns([:zone])
     @provider.expects(:conn).returns(conn)
-    assert_equal :zone, @provider.send(:get_zone, 'test.example.com')
+    assert_equal :zone, @provider.send(:get_zone, 'test.example.com.')
   end
 
   def test_get_zone_reverse
     conn = mock()
-    conn.expects(:get_zones).with('1.1.1.').returns([:zone])  # FIXME, incorrect rDNS zone
+    conn.expects(:get_zones).with('2.1.10.in-addr.arpa.').returns([:zone])
     @provider.expects(:conn).returns(conn)
-    assert_equal :zone, @provider.send(:get_zone, '10.1.1.1')
-  end
-
-  def test_dns_find_forward
-    resolver = mock()
-    resolver.expects(:getaddress).with('test.example.com').returns('10.1.1.1')
-    @provider.expects(:resolver).returns(resolver)
-    assert_equal '10.1.1.1', @provider.send(:dns_find, 'test.example.com')
-  end
-
-  def test_dns_find_forward_not_found
-    resolver = mock()
-    resolver.expects(:getaddress).with('test.example.com').raises(Resolv::ResolvError)
-    @provider.expects(:resolver).returns(resolver)
-    refute @provider.send(:dns_find, 'test.example.com')
-  end
-
-  def test_dns_find_reverse
-    resolver = mock()
-    resolver.expects(:getname).with('3.2.1.10').returns('test.example.com')
-    @provider.expects(:resolver).returns(resolver)
-    assert_equal 'test.example.com', @provider.send(:dns_find, '10.1.2.3')
-  end
-
-  def test_dns_find_reverse_not_found
-    resolver = mock()
-    resolver.expects(:getname).with('3.2.1.10').raises(Resolv::ResolvError)
-    @provider.expects(:resolver).returns(resolver)
-    refute @provider.send(:dns_find, '10.1.2.3')
-  end
-
-  private
-
-  def fqdn
-    'test.example.com'
-  end
-
-  def ip
-    '10.1.1.1'
+    assert_equal :zone, @provider.send(:get_zone, '3.2.1.10.in-addr.arpa.')
   end
 end


### PR DESCRIPTION
This includes a rewrite to 1.13 dependency injection and use of the [currently unmerged](https://github.com/theforeman/smart-proxy/pull/492) boiler plate and removing a lot of the code. In the process it adds support for AAAA and CNAME records. The old code also suggests that the deletion was broken in case you had multiple records for the same name. This is common when you have A and AAAA records, but can also happen with just one record type. That is now also handled.

Note that this is still untested since I don't have access to route53 and the smart-proxy PR also needs testing in itself.